### PR TITLE
[WIP]create controller and models about group and group_user

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,0 +1,13 @@
+class GroupsController < ApplicationController
+  def new
+  end
+
+  def create
+  end
+
+  def edit
+  end
+  
+  def update
+  end
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,5 @@
+class Group < ApplicationRecord
+  has_many :group_users
+  has_many :users, through: :group_users
+  validates :name, presence: true, uniqueness: true
+end

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -1,0 +1,4 @@
+class GroupUser < ApplicationRecord
+  belongs_to :group
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,9 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_many :messages
+  has_many :group_users
+  has_many :groups, through: :group_users
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,6 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root to: 'messages#index'
-  resources :users, only: [:edit, :update]
+  resources :users, only: [:index, :edit, :update]
+  resources :groups, only:[:new, :create, :edit, :update]
 end

--- a/db/migrate/20191102180009_create_groups.rb
+++ b/db/migrate/20191102180009_create_groups.rb
@@ -1,0 +1,10 @@
+class CreateGroups < ActiveRecord::Migration[5.0]
+  def change
+    create_table :groups do |t|
+      t.string :name, null: false
+      #rails5からインデックスの貼り方が以下の通りに変わった。
+      t.index :name, unique: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20191102180022_create_group_users.rb
+++ b/db/migrate/20191102180022_create_group_users.rb
@@ -1,0 +1,10 @@
+class CreateGroupUsers < ActiveRecord::Migration[5.0]
+  def change
+    create_table :group_users do |t|
+      #references型を使うと、_idのカラムが自動生成される他、インデックスが貼られる。
+      t.references :group, foreign_key: true
+      t.references :user, foreign_key: true
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
What
グループ機能を作成する。
groupモデルとgroup_userモデル、groupコントローラーを作成。
groupコントローラーには、groupの新規作成・編集機能を携えるため、new create edit updateのアクションを追加。それぞれのルーティングをroutes.rbに記載した。

groupモデルにはindexを設定したnameカラムを設けた。
group_userモデルはuser_idとgroup_idを設け、それぞれ外部キー制約を指定した。
user、group、group_userそれぞれのモデルに関係性を記述し、アソシエーションを設定した。

Why
グループ機能はチャットグループを作成する根幹機能であるため。